### PR TITLE
fix: support for engine ipc but forgot to initialize ipc_server_config

### DIFF
--- a/crates/node-core/src/args/rpc_server.rs
+++ b/crates/node-core/src/args/rpc_server.rs
@@ -475,7 +475,9 @@ impl RethRpcConfig for RpcServerArgs {
 
         let mut builder = AuthServerConfig::builder(jwt_secret).socket_addr(address);
         if self.auth_ipc {
-            builder = builder.ipc_endpoint(self.auth_ipc_path.clone());
+            builder = builder
+                .ipc_endpoint(self.auth_ipc_path.clone())
+                .with_ipc_config(self.ipc_server_builder())
         }
         Ok(builder.build())
     }


### PR DESCRIPTION
support for engine api over ipc but forgot to initialize `ipc_server_config`