### PR TITLE
fix: resolve compile errors when feature optimism is on

### DIFF
--- a/crates/optimism/evm/src/l1.rs
+++ b/crates/optimism/evm/src/l1.rs
@@ -263,10 +263,10 @@ impl RethL1BlockInfo for L1BlockInfo {
 pub fn ensure_create2_deployer<DB>(
     chain_spec: Arc<OpChainSpec>,
     timestamp: u64,
-    db: &mut revm::State<DB>,
+    db: &mut revm::db::State<DB>,
 ) -> Result<(), DB::Error>
 where
-    DB: revm::Database,
+    DB: revm::DatabaseRef,
 {
     // If the canyon hardfork is active at the current timestamp, and it was not active at the
     // previous block timestamp (heuristically, block time is not perfectly constant at 2s), and the
@@ -284,6 +284,7 @@ where
         let mut acc_info = acc.account_info().unwrap_or_default();
         acc_info.code_hash = CREATE_2_DEPLOYER_CODEHASH;
         acc_info.code = Some(Bytecode::new_raw(Bytes::from_static(&CREATE_2_DEPLOYER_BYTECODE)));
+        drop(acc);
 
         // Convert the cache account back into a revm account and mark it as touched.
         let mut revm_acc: revm::primitives::Account = acc_info.into();

--- a/crates/optimism/payload/src/builder.rs
+++ b/crates/optimism/payload/src/builder.rs
@@ -452,7 +452,7 @@ where
     // calculate the state root
     let hashed_state = HashedPostState::from_bundle_state(&execution_outcome.state().state);
     let (state_root, trie_output) = {
-        let state_provider = db.database.0.inner.borrow_mut();
+        let state_provider = db.database.inner.borrow_mut();
         state_provider.db.state_root_with_updates(hashed_state.clone()).inspect_err(|err| {
             warn!(target: "payload_builder",
                 parent_hash=%parent_block.hash(),


### PR DESCRIPTION
**Steps to verify**

1. Go to `crates/optimism/bin/Cargo.toml`, enable feature `optimism`:

```diff
-default = ["jemalloc"]
+default = ["jemalloc", "optimism"]
```

2. Run `cargo clippy` or `cargo build --package op-reth`