### PR TITLE
docs: fix broken link to build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ When updating this, also update:
 
 The Minimum Supported Rust Version (MSRV) of this project is [1.81.0](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html).
 
-See the book for detailed instructions on how to [build from source](https://paradigmxyz.github.io/reth/installation/source.html).
+See the book for detailed instructions on how to [build from source](https://reth.rs/installation/installation.html).
 
 To fully test Reth, you will need to have [Geth installed](https://geth.ethereum.org/docs/getting-started/installing-geth), but it is possible to run a subset of tests without Geth.
 


### PR DESCRIPTION
**What changed? Why?**
Replaced outdated/broken link (`paradigmxyz.github.io/reth/installation/source.html`)  
with the new working link to the official docs (`https://reth.rs/installation/installation.html`).

**Notes to reviewers**
- Only README.md was updated.
- Fixes broken reference in the "Building and testing" section.

**How has it been tested?**
- Verified that the new link is live and loads the correct installation instructions.
